### PR TITLE
Update documentation for templates

### DIFF
--- a/docs/kwc-cms/customize-components/content-template.md
+++ b/docs/kwc-cms/customize-components/content-template.md
@@ -1,64 +1,61 @@
-#STYLING - TEMPLATE
+# Templates
 
-For changing the Html output of a component create a Component.tpl or a `Component.twig` file in the component folder. 
-It will be picked up automatically. Templates from parent component classes can't be used if a component has it's own template.
+To change a component's HTML output, you can create a `Component.twig` file in the component's folder.  
+The file will be used after the next build of the project.
 
-To allow styling scoped to this component you should always include a div with `class="$this->cssClass"` in `Component.tpl` 
-or with `class="{{ cssClass }}"` in `Component.twig` file as outer element.
+For detailed information on how to use the twig template-engine, you can read the <a href="https://twig.symfony.com/" target="_blank">official twig-documentation</a>.
 
-The templates are rendered using `Zend_View`. You can add variables to the template by implementing `getTemplateVars` in the 
-Php class.
+## Example: Component.twig
+In the `Component.twig` you have access to a variable `rootElementClass`.  
+This is a class-name unique to your component.
 
-###Tpl - Example:
+```twig
+<div class="{{ rootElementClass }}">
+    <h1>Example content</h1>
+</div>
+```
 
-    <div class="<?=$this->cssClass?>
-        <h1>foo</h1>
-    </div>
-    
-###Twig - Example:
+## Styling the template
+To style the html of your component, you can add a `Component.scss` file.  
+You can then add your styles to the css-selector `.kwcClass`, this will reference the `rootElementClass` set in your `Component.twig`. 
+ 
+```scss
+.kwcClass {
+    // Styles for the html-element with the class "rootElementClass".
+}
+```
 
-    <div class="{{ cssClass }}">
-            <h1>Some content</h1>
-    </div>
-    
-###Twig - Blocks
+## Defining variables for your template
 
-With a block we can change parts of a template. It's a better approach than to copy the whole template.
+You can access anything returned by the `getTemplateVars()` function of your `Component.php` like follows: 
 
-    <div class="{{ cssClass }}">
-        {% block replaceableContent %}
-            <h1>Some content you can overwrite in a Childcomponent</h1>
-        {% endblock %}
-    </div>
-    
-    
-###Twig - Overwrite parts of a template:
+```php
+public function getTemplateVars(Kwf_Component_Renderer_Abstract $renderer)
+{
+    $ret = parent::getTemplateVars($renderer);
+    $ret['myText'] = "Some text";
+    return $ret;
+}
+```
 
-To change only parts of a parent template by using the blockelements, simple make a Component.twig and extend from 
-the template you need and overwrite the blockelement you want to change. It's a better approach than copy the whole 
-template and overwrite it.
+```twig
+<div class="{{ rootElementClass }}">
+    {{ myText }}
+</div>
+```
 
-    {% extends renderer.getComponentTemplate("Kwc_Menu_Mobile_Component") %}
-     
-    <div class="{{ cssClass }}">
-        ...
-    </div>
-    
-    
-###Twig - Php Variables:
+You can also access anything in the `placeholder` array returned in the `getSettings()` function of your `Component.php` like follows:
+```php
+public static function getSettings($param = null)
+{
+    $ret = parent::getSettings($param);
+    $ret['placeholder']['myText'] = "Some text";
+    return $ret;
+}
+```
 
-Variables defined in the `getSettings()` function like `$ret['placeholder']['menuLink'] = trlKwfStatic('Menu');` 
-are accessible like that.
-
-    <div class="{{ cssClass }}">
-        {{ placeholder.menuLink }}
-    </div>
-    
-
-###Twig - Php Variables:
-
-Variables defined in the `getTemplateVars()` function like `$ret['title'] = 'title';` are accessible like that.
-
-    <div class="{{ cssClass }}">
-        {{ title }}
-    </div>
+```twig
+<div class="{{ rootElementClass }}">
+    {{ placeholder.myText }}
+</div>
+```

--- a/docs/kwc-cms/customize-components/view-helpers.md
+++ b/docs/kwc-cms/customize-components/view-helpers.md
@@ -1,4 +1,57 @@
-#VIEW HELPER
+# Template helpers
+Koala provides a set of helper classes for html based on `Zend_View` helpers.  
+You can find the full list under `/Kwf/View/Helper/` or you can search for them in our [docs](http://www.koala-framework.org/docs/).
 
-Koala provides a set of helper classes for html based on `Zend_View` helpers. 
-You can find them at `/Kwf/View/Helper/`. Search for it in our [docs](http://www.koala-framework.org/docs/).
+## Extend another twig file
+
+Extend a component's `Component.twig` file:
+```twig
+{% extends renderer.getComponentTemplate("MyComponent") %}
+```
+
+Extend any twig file:
+```twig
+{% extends "path/to/my/template.twig" %}
+```
+
+## Render an image-tag
+
+```twig
+{{ renderer.image("/assets/web/images/myImg.png", "Alt text")) }}
+```
+
+**Render an image-tag with html-attributes and inline styles:**  
+*This should only be used if styling with css is not possible, for instance in HTML-Emails.*
+
+```twig
+{{ renderer.image('/assets/web/images/myImg.png', "Alt text", {'width': 100, 'height': 40, 'border': 0, 'style': 'vertical-align: middle; text-decoration: none;'}) }}
+```
+
+## Render a link to a component's page
+
+```twig
+{{ renderer.componentLink(targetComponent, "Link text")) }}
+```
+
+**Render a link to a component's page with inline styles:**  
+*This should only be used if styling with css is not possible, for instance in HTML-Emails.*
+
+```twig
+{{ renderer.componentLink(targetComponent, "Link Text", {'style': 'text-decoration: none;'}) }}
+```
+
+## Mail Link
+This encodes an email address, so it cannot be found too easily by crawlers looking for spam targets.
+
+```twig
+{{ "koal@koala-framework.org"|mailLink }}
+```
+
+This will be converted to the following HTML.   
+As soon as JS is loaded it will be decoded and will function like any other mailto-link.
+
+```html
+<a href="mailto:koal(kwfat)koala-framework(kwfdot)org">
+    <span class="kwfEncodedMail">koal(kwfat)koala-framework(kwfdot)org</span>
+</a>
+```


### PR DESCRIPTION
Remove mention of twig-blocks, they are not specific to koala and can
be found in the official twig-docs.
Show usage examples of common template helpers.

The link to the twig-docs is HTML to use target="_blank".
See: https://stackoverflow.com/a/4425223/4625218